### PR TITLE
feat: support events on abstract classes

### DIFF
--- a/src/event-mixin.ts
+++ b/src/event-mixin.ts
@@ -2,7 +2,7 @@
 import { TypedEvent } from './typed-event';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/ban-types
-type Constructor = new (...args: any[]) => {};
+type Constructor = (new (...args: any[]) => {}) | (abstract new (...args: any[]) => {});
 
 // Extract the 'Handler' type from the given TypedEvent
 type eventHandlerType<Type> = Type extends TypedEvent<infer X> ? X : never;


### PR DESCRIPTION
Before this PR, trying to add the events mixin to an abstract class would fail because it wouldn't pass the `Constructor` constraint.  This PR tweaks that constraint to allow for abstract classes.