### PR TITLE
feat: add method to remove all listeners

### DIFF
--- a/src/event-mixin.spec.ts
+++ b/src/event-mixin.spec.ts
@@ -109,4 +109,17 @@ describe('a child class', () => {
     expect(eventOneArgs).toHaveLength(0); // Should be 0, as all listeners should be removed
     expect(eventThreeArgs).toHaveLength(0); // Should be 0, as all listeners should be removed
   });
+
+  it('should remove all handlers from inherited classes when removeAllListeners is called', () => {
+    expect.hasAssertions();
+
+    const eventTwoArgs: boolean[] = [];
+    myClass.on('eventTwo', (value: boolean) => eventTwoArgs.push(value));
+
+    myClass.removeAllListeners();
+
+    myClass.fireEventTwo();
+
+    expect(eventTwoArgs).toHaveLength(0); // Should be 0, as all listeners should be removed
+  });
 });

--- a/src/event-mixin.spec.ts
+++ b/src/event-mixin.spec.ts
@@ -42,6 +42,22 @@ describe('a class with events', () => {
     expect(handlerTwoArgs).toHaveLength(1);
     expect(handlerTwoArgs[0]).toBe(42);
   });
+
+  it('should remove all handlers when removeAllListeners is called', () => {
+    expect.hasAssertions();
+    const handlerOneArgs: number[] = [];
+    const handler = (value: number) => {
+      handlerOneArgs.push(value);
+    };
+    myClass.on('eventOne', handler);
+    myClass.fireEventOne();
+    expect(handlerOneArgs).toHaveLength(1);
+    expect(handlerOneArgs[0]).toBe(42);
+
+    myClass.removeAllListeners();
+    myClass.fireEventOne();
+    expect(handlerOneArgs).toHaveLength(1); // Should still be 1, as all listeners should be removed
+  });
 });
 
 interface ChildEvents {
@@ -74,5 +90,23 @@ describe('a child class', () => {
 
     expect(eventOneArgs).toHaveLength(1);
     expect(eventThreeArgs).toHaveLength(1);
+  });
+
+  it('should remove all handlers from parent and child when removeAllListeners is called', () => {
+    expect.hasAssertions();
+
+    const eventOneArgs: number[] = [];
+    const eventThreeArgs: string[] = [];
+
+    myClass.on('eventOne', (value: number) => eventOneArgs.push(value));
+    myClass.on('eventThree', (value: string) => eventThreeArgs.push(value));
+
+    myClass.removeAllListeners();
+
+    myClass.fireEventOne();
+    myClass.fireEventThree();
+
+    expect(eventOneArgs).toHaveLength(0); // Should be 0, as all listeners should be removed
+    expect(eventThreeArgs).toHaveLength(0); // Should be 0, as all listeners should be removed
   });
 });

--- a/src/event-mixin.ts
+++ b/src/event-mixin.ts
@@ -68,12 +68,25 @@ export function AddEvents<TBase extends Constructor, U>(Base: TBase) {
      * Remove all event listeners from all events.
      */
     removeAllListeners() {
-      Object.keys(this).forEach((eventName) => {
-        const event = (this as any)[eventName];
-        if (event instanceof TypedEvent) {
-          event.removeAllListeners();
+      /**
+       * Recursively remove all listeners from the given object and its prototype chain. This is
+       * necessary because the events may be defined on the prototype chain.
+       *
+       * @param obj - The object to remove listeners from.
+       */
+      function removeListeners(obj: any) {
+        if (!obj || obj === Object.prototype) {
+          return;
         }
-      });
+        Object.keys(obj).forEach((eventName) => {
+          const event = obj[eventName];
+          if (event instanceof TypedEvent) {
+            event.removeAllListeners();
+          }
+        });
+        removeListeners(Object.getPrototypeOf(obj));
+      }
+      removeListeners(this);
     }
   };
 }

--- a/src/event-mixin.ts
+++ b/src/event-mixin.ts
@@ -63,6 +63,18 @@ export function AddEvents<TBase extends Constructor, U>(Base: TBase) {
     off<K extends keyof U, E extends eventHandlerType<U[K]>>(eventName: K, handler: E) {
       (this as any)[eventName].off(handler);
     }
+
+    /**
+     * Remove all event listeners from all events.
+     */
+    removeAllListeners() {
+      Object.keys(this).forEach((eventName) => {
+        const event = (this as any)[eventName];
+        if (event instanceof TypedEvent) {
+          event.removeAllListeners();
+        }
+      });
+    }
   };
 }
 

--- a/src/typed-event.ts
+++ b/src/typed-event.ts
@@ -57,4 +57,11 @@ export class TypedEvent<T extends Handler> {
   emit(...args: Parameters<T>): void {
     this.emitter.emit('event', ...args);
   }
+
+  /**
+   * Remove all listeners from this event.
+   */
+  removeAllListeners(): void {
+    this.emitter.removeAllListeners('event');
+  }
 }


### PR DESCRIPTION
This PR adds a `removeAllListeners` method to the `AddEvents` mixin, allowing for the removal of all event listeners from instances of classes using this mixin. The implementation iterates through all `TypedEvent` members and calls `removeAllListeners` on each, ensuring a clean state. Unit tests have been included to verify that the method correctly removes all listeners for both parent and child classes.