### PR TITLE
feat: awaitable emit

### DIFF
--- a/src/typed-event.spec.ts
+++ b/src/typed-event.spec.ts
@@ -63,4 +63,124 @@ describe('TypedEvent', () => {
       expect(handlerTwoArgs).toHaveLength(2);
     });
   });
+
+  describe('emitAsync', () => {
+    it('should return a promise that resolves', async () => {
+      expect.hasAssertions();
+
+      const asyncEvent = new TypedEvent<(value: number) => void>();
+      const handlerArgs: number[] = [];
+      asyncEvent.on((value: number) => handlerArgs.push(value));
+
+      await asyncEvent.emitAsync(42);
+
+      expect(handlerArgs).toHaveLength(1);
+      expect(handlerArgs[0]).toBe(42);
+    });
+
+    it('should wait for async handlers to complete', async () => {
+      expect.hasAssertions();
+
+      const asyncEvent = new TypedEvent<(value: number) => Promise<void>>();
+      const executionOrder: string[] = [];
+
+      asyncEvent.on(async (value: number) => {
+        executionOrder.push('handler1-start');
+        await new Promise((resolve) => setTimeout(resolve, 50));
+        executionOrder.push(`handler1-end-${value}`);
+      });
+
+      asyncEvent.on(async (value: number) => {
+        executionOrder.push('handler2-start');
+        await new Promise((resolve) => setTimeout(resolve, 30));
+        executionOrder.push(`handler2-end-${value}`);
+      });
+
+      executionOrder.push('before-emit');
+      await asyncEvent.emitAsync(100);
+      executionOrder.push('after-emit');
+
+      expect(executionOrder).toStrictEqual([
+        'before-emit',
+        'handler1-start',
+        'handler2-start',
+        'handler2-end-100',
+        'handler1-end-100',
+        'after-emit',
+      ]);
+    });
+
+    it('should handle multiple async handlers', async () => {
+      expect.hasAssertions();
+
+      const asyncEvent = new TypedEvent<(value: number) => Promise<number>>();
+      const results: number[] = [];
+
+      asyncEvent.on(async (value: number) => {
+        await new Promise((resolve) => setTimeout(resolve, 10));
+        results.push(value * 2);
+        return value * 2;
+      });
+
+      asyncEvent.on(async (value: number) => {
+        await new Promise((resolve) => setTimeout(resolve, 5));
+        results.push(value * 3);
+        return value * 3;
+      });
+
+      asyncEvent.on(async (value: number) => {
+        await new Promise((resolve) => setTimeout(resolve, 15));
+        results.push(value * 4);
+        return value * 4;
+      });
+
+      await asyncEvent.emitAsync(10);
+
+      expect(results).toHaveLength(3);
+      expect(results).toContain(20);
+      expect(results).toContain(30);
+      expect(results).toContain(40);
+    });
+
+    it('should handle synchronous handlers', async () => {
+      expect.hasAssertions();
+
+      const asyncEvent = new TypedEvent<(value: number) => void>();
+      const handlerArgs: number[] = [];
+
+      asyncEvent.on((value: number) => handlerArgs.push(value));
+      asyncEvent.on((value: number) => handlerArgs.push(value * 2));
+
+      await asyncEvent.emitAsync(5);
+
+      expect(handlerArgs).toStrictEqual([5, 10]);
+    });
+
+    it('should handle mixed sync and async handlers', async () => {
+      expect.hasAssertions();
+
+      const asyncEvent = new TypedEvent<(value: number) => void | Promise<void>>();
+      const results: string[] = [];
+
+      asyncEvent.on((value: number) => {
+        results.push(`sync-${value}`);
+      });
+
+      asyncEvent.on(async (value: number) => {
+        await new Promise((resolve) => setTimeout(resolve, 10));
+        results.push(`async-${value}`);
+      });
+
+      asyncEvent.on((value: number) => {
+        results.push(`sync2-${value}`);
+      });
+
+      await asyncEvent.emitAsync(7);
+
+      expect(results).toHaveLength(3);
+      expect(results).toContain('sync-7');
+      expect(results).toContain('async-7');
+      expect(results).toContain('sync2-7');
+    });
+  });
 });

--- a/src/typed-event.ts
+++ b/src/typed-event.ts
@@ -57,4 +57,16 @@ export class TypedEvent<T extends Handler> {
   emit(...args: Parameters<T>): void {
     this.emitter.emit('event', ...args);
   }
+
+  /**
+   * Emit the event and wait for all handlers to complete if they return promises.
+   *
+   * @param args - The arguments to the event.
+   *
+   * @returns A promise that resolves when all handlers have completed.
+   */
+  async emitAsync(...args: Parameters<T>): Promise<void> {
+    const handlers = this.emitter.listeners('event') as T[];
+    await Promise.all(handlers.map((handler) => Promise.resolve(handler(...args))));
+  }
 }


### PR DESCRIPTION
# Add `emitAsync` method to TypedEvent

## Summary

This PR adds a new `emitAsync` method to the `TypedEvent` class that allows emitting events and waiting for all handlers (including async handlers) to complete before resolving.

## Motivation

The existing `emit` method is fire-and-forget, which doesn't provide a way to:
- Wait for async event handlers to complete
- Ensure all handlers have finished executing before proceeding
- Handle async workflows that depend on event handler completion

This is particularly useful in scenarios where:
- Event handlers perform async operations (API calls, database queries, etc.)
- The caller needs to know when all event processing is complete
- Sequential processing is required after event emission

## This change implements...
- [x] A new feature
- [ ] A bug fix
- [ ] Other (please specify):

## Is this a breaking change?
- [ ] Yes
- [x] No

## I certify that...
- [x] All relevant unit and integration tests have passed and/or have been updated according to this change.

## Generative AI (GAI) Usage Disclosure
[Reference: Cisco GAI Coding Guidelines](https://cisco.sharepoint.com/sites/AIML/SitePages/Practice-Guide---GAI-Coding.aspx)

- [x] **Cisco approved GAI tool/IDE was used for coding** - eg: VSCode, Cursor, Windsurf, Codex, Claude code
- [ ] **No GAI** - Code was written entirely manually without GAI assistance

**If a GAI tool/IDE was used then select the category that best describes GAI usage in this PR:**
- [ ] **Manual Draft with GAI Refinement** - I/we created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code) *(Default)*
- [x] **GAI Draft with Manual Customization** - GAI tool was used to create a draft that I/we subsequently customized or modified.
- [ ] **GAI Generated Code** - Code was generated entirely by GAI

**Additional GAI Usage Details (Optional):**
<!-- Provide any additional context about GAI usage, tools used (e.g., Claude Code, Copilot, ChatGPT), or specific areas where GAI was applied -->
